### PR TITLE
fix: error not exit issue

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Exit immediately if a pipeline returns a non-zero status.
+set -e
+
 # Add Prviate Key
 add_ssh_key() {
 	mkdir -p ~/.ssh/


### PR DESCRIPTION
Change the values of shell options to exit immediately if a pipeline returns a non-zero status.